### PR TITLE
Api redesign

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import pkg from './package.json';
 import babel from 'rollup-plugin-babel';
 
 export default {
-  input: 'src/main.js',
+  input: 'src/index.js',
   output: {
     format: 'umd',
     name: 'Topologica',

--- a/src/dataFlowGraph.js
+++ b/src/dataFlowGraph.js
@@ -34,18 +34,18 @@ export const DataFlowGraph = options => {
     .every(property => values.has(property))
 
   if (options) {
-    Object.entries(options).forEach(entry => {
-      const [ property, { fn, inputs } ] = entry;
+    Object.entries(options).forEach(([ property, fn ]) => {
+      const { dependencies } = fn;
 
       const propertySync = isAsync(fn) ? property + "'" : property;
 
-      inputs.forEach(input => {
+      dependencies.forEach(input => {
         graph.addEdge(input, propertySync);
       });
 
       functions.set(propertySync, () => {
-        if (allDefined(inputs)) {
-          const output = fn(getAll(inputs));
+        if (allDefined(dependencies)) {
+          const output = fn(getAll(dependencies));
           isAsync(fn)
             ? output.then(value => set({[property]: value}))
             : values.set(property, output);

--- a/src/graph.js
+++ b/src/graph.js
@@ -17,7 +17,6 @@ export default () => {
   const depthFirstSearch = sourceNodes => {
     visited.clear();
     const nodeList = [];
-
     const DFSVisit = node => {
       if (!visited.has(node)) {
         visited.add(node);
@@ -25,19 +24,19 @@ export default () => {
         nodeList.push(node);
       }
     };
-
     sourceNodes.forEach(visited.add, visited);
-
-    sourceNodes.forEach(node => 
+    sourceNodes.forEach(node => {
       adjacent(node).forEach(DFSVisit)
-    );
-
+    });
     return nodeList;
   }
 
-  const topologicalSort = sourceNodes => {
-    return depthFirstSearch(sourceNodes).reverse();
-  };
+  const topologicalSort = sourceNodes =>
+    depthFirstSearch(sourceNodes)
+      .reverse();
 
-  return { addEdge, topologicalSort };
+  return {
+    addEdge,
+    topologicalSort
+  };
 }

--- a/src/graph.js
+++ b/src/graph.js
@@ -26,13 +26,11 @@ export default () => {
       }
     };
 
-    sourceNodes.forEach(node => {
-      visited.add(node);
-    });
+    sourceNodes.forEach(visited.add, visited);
 
-    sourceNodes.forEach(node => {
-      adjacent(node).forEach(DFSVisit);
-    });
+    sourceNodes.forEach(node => 
+      adjacent(node).forEach(DFSVisit)
+    );
 
     return nodeList;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import Graph from './graph'
 
 const isAsync = fn => fn && fn.constructor.name === 'AsyncFunction';
 
-export const DataFlowGraph = options => {
+const Topologica = options => {
   const values = new Map();
   const changed = new Set();
   const functions = new Map();
@@ -56,3 +56,5 @@ export const DataFlowGraph = options => {
 
   return { set, get };
 };
+
+export default Topologica;

--- a/src/main.js
+++ b/src/main.js
@@ -1,2 +1,1 @@
 export { DataFlowGraph } from './dataFlowGraph'
-export { ReactiveFunction } from './reactiveFunction'

--- a/src/main.js
+++ b/src/main.js
@@ -1,1 +1,0 @@
-export { DataFlowGraph } from './dataFlowGraph'

--- a/src/reactiveFunction.js
+++ b/src/reactiveFunction.js
@@ -1,8 +1,0 @@
-const parse = inputsStr => inputsStr
-  .split(',')
-  .map(input => input.trim());
-
-export const ReactiveFunction = (fn, inputsStr) => ({
-  fn,
-  inputs: parse(inputsStr)
-})

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,16 @@
 const Topologica = require('..');
 const assert = require('assert');
 
-const { DataFlowGraph, ReactiveFunction: λ } = Topologica;
+const { DataFlowGraph } = Topologica;
+
+const parse = dependenciesStr => dependenciesStr
+  .split(',')
+  .map(input => input.trim());
+
+const λ = (fn, dependenciesStr) => {
+  fn.dependencies = parse(dependenciesStr);
+  return fn;
+};
 
 describe('Topologica.js', () => {
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,6 @@
 const Topologica = require('..');
 const assert = require('assert');
 
-const { DataFlowGraph } = Topologica;
-
 const parse = dependenciesStr => dependenciesStr
   .split(',')
   .map(input => input.trim());
@@ -15,112 +13,123 @@ const λ = (fn, dependenciesStr) => {
 describe('Topologica.js', () => {
 
   it('Should set and get a value.', () => {
-    const dataFlow = DataFlowGraph();
-    dataFlow.set({
+    const state = Topologica();
+    state.set({
       foo: 'bar'
     });
-    assert.equal(dataFlow.get('foo'), 'bar');
+    assert.equal(state.get('foo'), 'bar');
   });
 
   it('Should compute a derived property.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       b: λ(({a}) => a + 1, 'a')
     });
-    dataFlow.set({
+    state.set({
       a: 5
     });
-    assert.equal(dataFlow.get('b'), 6);
+    assert.equal(state.get('b'), 6);
   });
 
   it('Should handle uninitialized property.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       b: λ(({a}) => a + 1, 'a')
     });
-    assert.equal(dataFlow.get('b'), undefined);
+    assert.equal(state.get('b'), undefined);
   });
 
   it('Should propagate changes synchronously.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       b: λ(({a}) => a + 1, 'a')
     });
 
-    dataFlow.set({
+    state.set({
       a: 2
     });
-    assert.equal(dataFlow.get('b'), 3);
+    assert.equal(state.get('b'), 3);
 
-    dataFlow.set({
+    state.set({
       a: 99
     });
-    assert.equal(dataFlow.get('b'), 100);
+    assert.equal(state.get('b'), 100);
   });
 
   it('Should compute a derived property with 2 hops.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       b: λ(({a}) => a + 1, 'a'),
       c: λ(({b}) => b + 1, 'b')
     });
-    dataFlow.set({
+    state.set({
       a: 5
     });
-    assert.equal(dataFlow.get('c'), 7);
+    assert.equal(state.get('c'), 7);
   });
 
   it('Should handle case of 2 inputs.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       fullName: λ(
         ({firstName, lastName}) => `${firstName} ${lastName}`,
         'firstName, lastName'
       )
     });
-    dataFlow.set({
+    state.set({
       firstName: 'Fred',
       lastName: 'Flintstone'
     });
-    assert.equal(dataFlow.get('fullName'), 'Fred Flintstone');
+    assert.equal(state.get('fullName'), 'Fred Flintstone');
+  });
+
+  it('Should accept an array of strings as dependencies.', () => {
+    const fullName = ({firstName, lastName}) => `${firstName} ${lastName}`;
+    fullName.dependencies = ['firstName', 'lastName'];
+    const state = Topologica({ fullName });
+    state.set({
+      firstName: 'Fred',
+      lastName: 'Flintstone'
+    });
+    assert.equal(state.get('fullName'), 'Fred Flintstone');
   });
 
   it('Should only execute when all inputs are defined.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       fullName: λ(
         ({firstName, lastName}) => `${firstName} ${lastName}`,
         'firstName, lastName'
       )
     });
 
-    dataFlow.set({
+    state.set({
       lastName: 'Flintstone'
     });
-    assert.equal(dataFlow.get('fullName'), undefined);
+    assert.equal(state.get('fullName'), undefined);
 
-    dataFlow.set({
+    state.set({
       firstName: 'Wilma'
     });
-    assert.equal(dataFlow.get('fullName'), 'Wilma Flintstone');
+    assert.equal(state.get('fullName'), 'Wilma Flintstone');
   });
 
   it('Should handle case of 3 inputs.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       d: λ(({a, b, c}) => a + b + c, 'a,b,c')
     });
-    dataFlow.set({
+    state.set({
       a: 5,
       b: 8,
       c: 2
     });
-    assert.equal(dataFlow.get('d'), 15);
+    assert.equal(state.get('d'), 15);
   });
 
   it('Should handle spaces in input string.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       d: λ(({a, b, c}) => a + b + c, '  a ,    b, c   ')
     });
-    dataFlow.set({
+    state.set({
       a: 5,
       b: 8,
       c: 2
     });
-    assert.equal(dataFlow.get('d'), 15);
+    assert.equal(state.get('d'), 15);
   });
 
   // Data flow graph, read from top to bottom.
@@ -132,16 +141,16 @@ describe('Topologica.js', () => {
   //    e   
   //
   it('Should evaluate not-too-tricky case.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       b: λ(({a}) => a + 1, 'a'),
       d: λ(({c}) => c + 1, 'c'),
       e: λ(({b, d}) => b + d, 'b, d')
     });
-    dataFlow.set({
+    state.set({
       a: 1,
       c: 2
     });
-    assert.equal(dataFlow.get('e'), (1 + 1) + (2 + 1));
+    assert.equal(state.get('e'), (1 + 1) + (2 + 1));
   });
 
   //      a
@@ -152,21 +161,21 @@ describe('Topologica.js', () => {
   //     \ /
   //      e   
   it('Should evaluate tricky case.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       b: λ(({a}) => a + 1, 'a'),
       c: λ(({b}) => b + 1, 'b'),
       d: λ(({a}) => a + 1, 'a'),
       e: λ(({b, d}) => b + d, 'b, d')
     });
-    dataFlow.set({
+    state.set({
       a: 5
     });
-    const a = dataFlow.get('a');
+    const a = state.get('a');
     const b = a + 1;
     const c = b + 1;
     const d = a + 1;
     const e = b + d;
-    assert.equal(dataFlow.get('e'), e);
+    assert.equal(state.get('e'), e);
   });
 
 
@@ -180,7 +189,7 @@ describe('Topologica.js', () => {
   //     \ / /
   //       h   
   it('Should evaluate trickier case.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       b: λ(({a}) => a + 1, 'a'),
       c: λ(({b}) => b + 1, 'b'),
       d: λ(({c}) => c + 1, 'c'),
@@ -189,10 +198,10 @@ describe('Topologica.js', () => {
       g: λ(({a}) => a + 1, 'a'),
       h: λ(({d, f, g}) => d + f + g, 'd, f, g')
     });
-    dataFlow.set({
+    state.set({
       a: 5
     });
-    const a = dataFlow.get('a');
+    const a = state.get('a');
     const b = a + 1;
     const c = b + 1;
     const d = c + 1;
@@ -200,21 +209,21 @@ describe('Topologica.js', () => {
     const f = e + 1;
     const g = a + 1;
     const h = d + f + g;
-    assert.equal(dataFlow.get('h'), h);
+    assert.equal(state.get('h'), h);
   });
 
   it('Should work with booleans.', () => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       b: λ(({a}) => !a, 'a')
     });
-    dataFlow.set({
+    state.set({
       a: false
     });
-    assert.equal(dataFlow.get('b'), true);
+    assert.equal(state.get('b'), true);
   });
 
   it('Should work with async functions.', done => {
-    const dataFlow = DataFlowGraph({
+    const state = Topologica({
       b: λ(
         async ({a}) => await Promise.resolve(a + 5),
         'a'
@@ -227,7 +236,7 @@ describe('Topologica.js', () => {
         'b'
       )
     });
-    dataFlow.set({
+    state.set({
       a: 5
     });
   });


### PR DESCRIPTION
Closes #15 

Summary of changes:

 * Api expects reactive functions as functions with a property `dependencies`, an array of strings.
 * The library no longer accepts a comma-separated string of dependencies.

Example:

```js
import Topologica from 'topologica';

const fullName = ({firstName, lastName}) => `${firstName} ${lastName}`;
fullName.dependencies = ['firstName', 'lastName'];

const state = Topologica({ fullName });
```