### PR TITLE
Restore whitelisted arg

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -14,18 +14,18 @@ export default () => {
   };
 
   const depthFirstSearch = sourceNodes => {
-    const visited = new Set();
+    const visited = {};
     const nodeList = [];
 
     function DFSVisit(node) {
-      if (!visited.has(node)) {
+      if (!visited[node]) {
         visit(node);
         nodeList.push(node);
       }
     };
 
     function visit(node) {
-      visited.add(node);
+      visited[node] = true;
       adjacent(node).forEach(DFSVisit);
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,29 +7,25 @@ const parse = dependencies => dependencies.split
 const Topologica = options => {
   const values = {};
   const functions = {};
-  let changed = {};
   const graph = Graph();
 
   const invoke = property => {
     functions[property]();
   };
 
-  const digest = () => {
-    graph
-      .topologicalSort(Object.keys(changed))
-      .forEach(invoke);
-    changed = {};
-  };
-
   const set = options => {
+    const changed = [];
     Object.keys(options).forEach(property => {
       const value = options[property];
       if (values[property] !== value) {
         values[property] = value;
-        changed[property] = true;
+        changed.push(property);
       }
     });
-    digest();
+
+    graph
+      .topologicalSort(changed)
+      .forEach(invoke);
   };
 
   const get = property => values[property];

--- a/src/index.js
+++ b/src/index.js
@@ -27,13 +27,15 @@ const Topologica = options => {
       .forEach(invoke);
   };
 
-  const defined = property => values[property] !== undefined;
-
-  const pick = properties => properties
-    .reduce((accumulator, property) => {
-      accumulator[property] = values[property];
-      return accumulator;
-    }, {});
+  const allDefined = dependencies => {
+    const arg = {};
+    return dependencies.every(property => {
+      if (values[property] !== undefined){
+        arg[property] = values[property];
+        return true;
+      }
+    }) ? arg : null;
+  };
 
   if (options) {
     Object.keys(options).forEach(property => {
@@ -45,8 +47,9 @@ const Topologica = options => {
       });
 
       functions[property] = () => {
-        if (dependencies.every(defined)) {
-          values[property] = fn(pick(dependencies));
+        const arg = allDefined(dependencies);
+        if (arg) {
+          values[property] = fn(arg);
         }
       };
     });

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ const parse = dependencies => dependencies.split
 const Topologica = options => {
   const values = {};
   const functions = {};
+  let changed = {};
   const graph = Graph();
-  const changed = new Set();
 
   const invoke = property => {
     functions[property]();
@@ -16,9 +16,9 @@ const Topologica = options => {
 
   const digest = () => {
     graph
-      .topologicalSort(Array.from(changed.values()))
+      .topologicalSort(Object.keys(changed))
       .forEach(invoke);
-    changed.clear();
+    changed = {};
   };
 
   const set = options => {
@@ -26,7 +26,7 @@ const Topologica = options => {
       const value = options[property];
       if (values[property] !== value) {
         values[property] = value;
-        changed.add(property);
+        changed[property] = true;
       }
     });
     digest();

--- a/src/index.js
+++ b/src/index.js
@@ -27,12 +27,17 @@ const Topologica = options => {
       .forEach(invoke);
   };
 
-  let dependenciesObject;
-  const defined = property => {
-    if (values[property] !== undefined) {
-      dependenciesObject[property] = values[property];
-      return true;
+  const allDefined = dependencies => {
+    const dependenciesObject = {};
+    const defined = property => {
+      if (values[property] !== undefined) {
+        dependenciesObject[property] = values[property];
+        return true;
+      }
     }
+    return dependencies.every(defined)
+      ? dependenciesObject
+      : null;
   }
 
   if (options) {
@@ -45,8 +50,8 @@ const Topologica = options => {
       });
 
       functions[property] = () => {
-        dependenciesObject = {};
-        if (dependencies.every(defined)) {
+        const dependenciesObject = allDefined(dependencies);
+        if (dependenciesObject) {
           values[property] = fn(dependenciesObject);
         }
       };

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,8 @@ const Topologica = options => {
   const set = options => {
     const changed = [];
     Object.keys(options).forEach(property => {
-      const value = options[property];
-      if (values[property] !== value) {
-        values[property] = value;
+      if (values[property] !== options[property]) {
+        values[property] = options[property];
         changed.push(property);
       }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -4,15 +4,6 @@ const parse = dependencies => dependencies.split
   ? dependencies.split(',').map(str => str.trim())
   : dependencies;
 
-const pick = (values, dependencies) => {
-  const onlyDependencies = {};
-  for(let i = 0; i < dependencies.length; i++) {
-    const dependency = dependencies[i];
-    onlyDependencies[dependency] = values[dependency];
-  }
-  return onlyDependencies;
-};
-
 const Topologica = options => {
   const values = {};
   const functions = {};
@@ -36,8 +27,13 @@ const Topologica = options => {
       .forEach(invoke);
   };
 
-  const allDefined = properties => properties
-    .every(property => values[property] !== undefined);
+  let dependenciesObject;
+  const defined = property => {
+    if (values[property] !== undefined) {
+      dependenciesObject[property] = values[property];
+      return true;
+    }
+  }
 
   if (options) {
     Object.keys(options).forEach(property => {
@@ -49,8 +45,9 @@ const Topologica = options => {
       });
 
       functions[property] = () => {
-        if (allDefined(dependencies)) {
-          values[property] = fn(pick(values, dependencies));
+        dependenciesObject = {};
+        if (dependencies.every(defined)) {
+          values[property] = fn(dependenciesObject);
         }
       };
     });

--- a/src/index.js
+++ b/src/index.js
@@ -27,18 +27,13 @@ const Topologica = options => {
       .forEach(invoke);
   };
 
-  const allDefined = dependencies => {
-    const dependenciesObject = {};
-    const defined = property => {
-      if (values[property] !== undefined) {
-        dependenciesObject[property] = values[property];
-        return true;
-      }
-    }
-    return dependencies.every(defined)
-      ? dependenciesObject
-      : null;
-  }
+  const defined = property => values[property] !== undefined;
+
+  const pick = properties => properties
+    .reduce((accumulator, property) => {
+      accumulator[property] = values[property];
+      return accumulator;
+    }, {});
 
   if (options) {
     Object.keys(options).forEach(property => {
@@ -50,9 +45,8 @@ const Topologica = options => {
       });
 
       functions[property] = () => {
-        const dependenciesObject = allDefined(dependencies);
-        if (dependenciesObject) {
-          values[property] = fn(dependenciesObject);
+        if (dependencies.every(defined)) {
+          values[property] = fn(pick(dependencies));
         }
       };
     });

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,6 @@ const Topologica = options => {
       .forEach(invoke);
   };
 
-  const get = property => values[property];
-
   const allDefined = properties => properties
     .every(property => values[property] !== undefined);
 
@@ -49,7 +47,10 @@ const Topologica = options => {
     });
   }
 
-  return { set, get };
+  return {
+    set,
+    get: () => values
+  };
 };
 
 export default Topologica;

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,12 @@ const parse = dependencies => dependencies.split
 
 const Topologica = options => {
   const values = {};
-  const functions = new Map();
+  const functions = {};
   const graph = Graph();
   const changed = new Set();
 
   const invoke = property => {
-    functions.get(property)();
+    functions[property]();
   };
 
   const digest = () => {
@@ -46,11 +46,11 @@ const Topologica = options => {
         graph.addEdge(input, property);
       });
 
-      functions.set(property, () => {
+      functions[property] = () => {
         if (allDefined(dependencies)) {
           values[property] = fn(values);
         }
-      });
+      };
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const parse = dependencies => dependencies.split
   : dependencies;
 
 const Topologica = options => {
-  const values = new Map();
+  const values = {};
   const functions = new Map();
   const graph = Graph();
   const changed = new Set();
@@ -24,24 +24,18 @@ const Topologica = options => {
   const set = options => {
     Object.keys(options).forEach(property => {
       const value = options[property];
-      if (values.get(property) !== value) {
-        values.set(property, value);
+      if (values[property] !== value) {
+        values[property] = value;
         changed.add(property);
       }
     });
     digest();
   };
 
-  const get = values.get.bind(values);
-
-  const getAll = properties =>
-    properties.reduce((accumulator, property) => {
-      accumulator[property] = get(property);
-      return accumulator;
-    }, {});
+  const get = property => values[property];
 
   const allDefined = properties => properties
-    .every(values.has, values);
+    .every(property => values[property] !== undefined);
 
   if (options) {
     Object.keys(options).forEach(property => {
@@ -54,7 +48,7 @@ const Topologica = options => {
 
       functions.set(property, () => {
         if (allDefined(dependencies)) {
-          values.set(property, fn(getAll(dependencies)));
+          values[property] = fn(values);
         }
       });
     });

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,15 @@ const parse = dependencies => dependencies.split
   ? dependencies.split(',').map(str => str.trim())
   : dependencies;
 
+const pick = (values, dependencies) => {
+  const onlyDependencies = {};
+  for(let i = 0; i < dependencies.length; i++) {
+    const dependency = dependencies[i];
+    onlyDependencies[dependency] = values[dependency];
+  }
+  return onlyDependencies;
+};
+
 const Topologica = options => {
   const values = {};
   const functions = {};
@@ -41,7 +50,7 @@ const Topologica = options => {
 
       functions[property] = () => {
         if (allDefined(dependencies)) {
-          values[property] = fn(values);
+          values[property] = fn(pick(values, dependencies));
         }
       };
     });

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,7 @@ describe('Topologica.js', () => {
     state.set({
       foo: 'bar'
     });
-    assert.equal(state.get('foo'), 'bar');
+    assert.equal(state.get().foo, 'bar');
   });
 
   it('Should compute a derived property.', () => {
@@ -23,14 +23,14 @@ describe('Topologica.js', () => {
     state.set({
       a: 5
     });
-    assert.equal(state.get('b'), 6);
+    assert.equal(state.get().b, 6);
   });
 
   it('Should handle uninitialized property.', () => {
     const state = Topologica({
       b: λ(({a}) => a + 1, 'a')
     });
-    assert.equal(state.get('b'), undefined);
+    assert.equal(state.get().b, undefined);
   });
 
   it('Should propagate changes synchronously.', () => {
@@ -41,12 +41,12 @@ describe('Topologica.js', () => {
     state.set({
       a: 2
     });
-    assert.equal(state.get('b'), 3);
+    assert.equal(state.get().b, 3);
 
     state.set({
       a: 99
     });
-    assert.equal(state.get('b'), 100);
+    assert.equal(state.get().b, 100);
   });
 
   it('Should compute a derived property with 2 hops.', () => {
@@ -57,7 +57,7 @@ describe('Topologica.js', () => {
     state.set({
       a: 5
     });
-    assert.equal(state.get('c'), 7);
+    assert.equal(state.get().c, 7);
   });
 
   it('Should handle case of 2 inputs.', () => {
@@ -71,7 +71,7 @@ describe('Topologica.js', () => {
       firstName: 'Fred',
       lastName: 'Flintstone'
     });
-    assert.equal(state.get('fullName'), 'Fred Flintstone');
+    assert.equal(state.get().fullName, 'Fred Flintstone');
   });
 
   it('Should accept an array of strings as dependencies.', () => {
@@ -82,7 +82,7 @@ describe('Topologica.js', () => {
       firstName: 'Fred',
       lastName: 'Flintstone'
     });
-    assert.equal(state.get('fullName'), 'Fred Flintstone');
+    assert.equal(state.get().fullName, 'Fred Flintstone');
   });
 
   it('Should accept a comma delimited string as dependencies.', () => {
@@ -93,7 +93,7 @@ describe('Topologica.js', () => {
       firstName: 'Fred',
       lastName: 'Flintstone'
     });
-    assert.equal(state.get('fullName'), 'Fred Flintstone');
+    assert.equal(state.get().fullName, 'Fred Flintstone');
   });
 
   it('Should only execute when all inputs are defined.', () => {
@@ -107,12 +107,12 @@ describe('Topologica.js', () => {
     state.set({
       lastName: 'Flintstone'
     });
-    assert.equal(state.get('fullName'), undefined);
+    assert.equal(state.get().fullName, undefined);
 
     state.set({
       firstName: 'Wilma'
     });
-    assert.equal(state.get('fullName'), 'Wilma Flintstone');
+    assert.equal(state.get().fullName, 'Wilma Flintstone');
   });
 
   it('Should handle case of 3 inputs.', () => {
@@ -124,7 +124,7 @@ describe('Topologica.js', () => {
       b: 8,
       c: 2
     });
-    assert.equal(state.get('d'), 15);
+    assert.equal(state.get().d, 15);
   });
 
   it('Should handle spaces in input string.', () => {
@@ -136,7 +136,7 @@ describe('Topologica.js', () => {
       b: 8,
       c: 2
     });
-    assert.equal(state.get('d'), 15);
+    assert.equal(state.get().d, 15);
   });
 
   // Data flow graph, read from top to bottom.
@@ -157,7 +157,7 @@ describe('Topologica.js', () => {
       a: 1,
       c: 2
     });
-    assert.equal(state.get('e'), (1 + 1) + (2 + 1));
+    assert.equal(state.get().e, (1 + 1) + (2 + 1));
   });
 
   //      a
@@ -177,12 +177,12 @@ describe('Topologica.js', () => {
     state.set({
       a: 5
     });
-    const a = state.get('a');
+    const a = state.get().a;
     const b = a + 1;
     const c = b + 1;
     const d = a + 1;
     const e = b + d;
-    assert.equal(state.get('e'), e);
+    assert.equal(state.get().e, e);
   });
 
 
@@ -208,7 +208,7 @@ describe('Topologica.js', () => {
     state.set({
       a: 5
     });
-    const a = state.get('a');
+    const a = state.get().a;
     const b = a + 1;
     const c = b + 1;
     const d = c + 1;
@@ -216,7 +216,7 @@ describe('Topologica.js', () => {
     const f = e + 1;
     const g = a + 1;
     const h = d + f + g;
-    assert.equal(state.get('h'), h);
+    assert.equal(state.get().h, h);
   });
 
   it('Should work with booleans.', () => {
@@ -226,7 +226,7 @@ describe('Topologica.js', () => {
     state.set({
       a: false
     });
-    assert.equal(state.get('b'), true);
+    assert.equal(state.get().b, true);
   });
 
   it('Should work with async functions.', done => {

--- a/test/test.js
+++ b/test/test.js
@@ -267,6 +267,20 @@ describe('Topologica.js', () => {
     assert.equal(invocations, 2);
   });
 
+  it('Should pass only dependencies into reactive functions.', () => {
+    const state = Topologica({
+      b: λ(
+        props => Object.keys(props),
+        'a'
+      )
+    });
+    state.set({
+      a: 'Foo',
+      foo: 'Bar'
+    });
+    assert.deepEqual(state.get().b, ['a']);
+  });
+
   it('Should be fast.', () => {
     const state = Topologica({
       b: λ(({a}) => a + 1, 'a'),
@@ -292,4 +306,5 @@ describe('Topologica.js', () => {
     console.log('Average: ' + (totalTime / numRuns));
     // 468.9
   }).timeout(7000);
+
 });


### PR DESCRIPTION
Not sure if we need this. It impacts performance and bundle size negatively, but also improves usability of the library by pre-empting bugs where a property is unpacked, but not defined as a dependency.

Imagine a scenario where you want to add a new dependency to a function, and you add it to the destructuring assignment, but forget to add it to the list of dependencies. Without this change, the property would be available on the argument, but it would not be tracked as a dependency.

Before:
 * Size: 956 bytes
 * Benchmark avg: 295 ms

After:
 * Size: 983 bytes
 * Benchmark avg: 400 ms