### PR TITLE
Chainable set

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ b.dependencies = ['a'];
 const c = ({b}) => b + 1;
 c.dependencies = ['b'];
 
-const state = Topologica({ b, c });
-
-state.set({ a: 5 });
+const state = Topologica({ b, c }).set({ a: 5 });
 assert.equal(state.get().c, 7);
 ```
+
+Note that `set` returns the `Topologica` instance, so it is chainable.
 
 <p align="center">
   <img src="https://cloud.githubusercontent.com/assets/68416/15385597/44a10522-1dc0-11e6-9054-2150f851db46.png">

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const Topologica = options => {
     functions[property]();
   };
 
-  const set = options => {
+  const set = function(options) {
     graph
       .topologicalSort(Object.keys(options).map(property => {
         if (values[property] !== options[property]) {
@@ -22,6 +22,7 @@ const Topologica = options => {
         }
       }))
       .forEach(invoke);
+    return this;
   };
 
   const allDefined = dependencies => {

--- a/test/test.js
+++ b/test/test.js
@@ -16,6 +16,11 @@ describe('Topologica.js', () => {
     assert.equal(state.get().foo, 'bar');
   });
 
+  it('Should chain set.', () => {
+    const state = Topologica({}).set({ foo: 'bar' });
+    assert.equal(state.get().foo, 'bar');
+  });
+
   it('Should compute a derived property.', () => {
     const state = Topologica({
       b: λ(({a}) => a + 1, 'a')


### PR DESCRIPTION
Closes #33 

This implementation returns `this`. It's simpler than the original implementation in #34, results in a slightly smaller bundle, and covers the desired use case.

Before:

```js
const state = Topologica({ circlesDOM });
state.set({ selection });
return state;
```

After:

```js
return Topologica({ circlesDOM }).set({ selection });
```

Full example: https://vizhub.com/curran/27c261085d8a48618c69f7983672903b
